### PR TITLE
Disable branch whitelist until migration to QGIS3 is completed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ python:
 virtualenv:
   system_site_packages: true
 
-branches:
-  only:
-    - master
+# Disable branch whitelist until migration to QGIS3 is completed
+#branches:
+#  only:
+#    - master
 
 -before_install:
   - sudo apt-get -qq -y update


### PR DESCRIPTION
If you need individual PRs for atomic changes (weel kind-of) I need to run Travis on all topic branches.

We can re-enable branch white-listing when the migration is completed.